### PR TITLE
fix: 修复视频滤镜器滑块显示错误问题

### DIFF
--- a/src/packages/VideoTools/VideoFilter/VideoFilter.js
+++ b/src/packages/VideoTools/VideoFilter/VideoFilter.js
@@ -144,8 +144,10 @@ function initPkg_VideoTools_Filter_Func() {
         overPanel = true;
     })
     filterPanel.addEventListener("mouseleave", function () {
-        filterPanel.style.display = "none"
-        overPanel = false;
+        setTimeout(() => {
+            filterPanel.style.display = "none"
+            overPanel = false;
+        }, 500);
     });
     
     document.getElementById("filter__reset").addEventListener("click", () => {


### PR DESCRIPTION
![qq22918914922917714320240815155037](https://github.com/user-attachments/assets/d4c31a8c-cd01-4da7-9f6a-99570b2a9574)

**问题描述**：如图所示，在视频滤镜器内，鼠标按下拖动滑动时离开容器后，滑块显示数值为0，而实际设置成功。

**处理**：将`mouseleave`对视频滤镜器隐藏增加500ms延时。