### PR TITLE
fix: 修改个人消费统计模块接口逻辑和加载逻辑

### DIFF
--- a/src/packages/MonthCost/MonthCost.js
+++ b/src/packages/MonthCost/MonthCost.js
@@ -98,11 +98,15 @@ async function getMonthCost_gift() {
 		}
 		
 		let ret = await MonthCost_queryData(url);
-		data = data.concat(ret.data);
-		if (ret.data.length < 20) {
-			hasMoreData = false;
+		if (ret.error == 1000) {
+			await new Promise(resolve => setTimeout(resolve, 2000));
 		} else {
-			id = ret.data[ret.data.length - 1].id;
+			data = data.concat(ret.data);
+			if (ret.data.length < 20) {
+				hasMoreData = false;
+			} else {
+				id = ret.data[ret.data.length - 1].id;
+			}
 		}
 	}
 
@@ -245,13 +249,14 @@ function MonthCost_updateCost() {
 		timeDiff = Math.abs(now - new Date(item.updateTime).getDate());
 		tmpCost = item.monthCost;
 		tmpTypeDetail = item.typeDetail || [];
+		document.getElementById("monthcost__money").innerText = String(tmpCost / 100);
+		typeDetail = tmpTypeDetail;
+		MonthCost_ContentAttrTitle();
+	}else{
+		document.getElementById("monthcost__money").innerHTML = `<span class="PlayerToolbar-dataLoadding"></span>`;
 	}
 
 	if (timeDiff >= 1) {
 		getMonthCost();
-	} else {
-		document.getElementById("monthcost__money").innerText = String(tmpCost / 100);
-		typeDetail = tmpTypeDetail;
-		MonthCost_ContentAttrTitle();
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/qianjiachun/douyuEx/pull/102#issuecomment-2572350892

## 修改：

1. 修改接口调用逻辑，接口返回 `{"error":1000,"msg":"请勿频繁操作。","data":null}` 时，睡眠延迟2000毫秒，2000毫秒后重新调用接口，若失败则继续睡眠延迟。

2. 修改**个人消费统计功能**页面加载初始化逻辑：
   1. `localStorage` 有值：**首先**读取 `localStorage` 的金额显示到页面；**然后**判断时间戳是否是同一天：
      - 是：结束流程；
      - 否：调用接口获取新数据，更新 `localStorage` 和页面金额。
   2. `localStorage` 无值：显示加载状态，调用接口获取数据，更新 `localStorage` 和页面金额。





```mermaid
flowchart TD
    A[判断 localStorage 是否为空] -->|有值| B[将值显示到页面金额文本]
    A -->|无值| E[显示 loading 状态]
    
    B --> C[判断时间戳是否是同一天]
    C -->|是| I
    C -->|否| D[调用接口获取数据]
    
    E --> D
    D --> G[更新 localStorage]
    G --> H[更新页面金额文本]
    H --> I[结束流程]
```